### PR TITLE
Ansible code bot recommendations

### DIFF
--- a/roles/run/tasks/health_checks/junos.yaml
+++ b/roles/run/tasks/health_checks/junos.yaml
@@ -8,5 +8,5 @@
 
 
 - name: Show Summary facts
-  debug:
+  ansible.builtin.debug:
     msg: "{{ bgp_health }}"

--- a/roles/run/tasks/health_checks/vyos.yaml
+++ b/roles/run/tasks/health_checks/vyos.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show ip bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/includes/configure.yaml
+++ b/roles/run/tasks/includes/configure.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Invoke configure function
-  include_role:
-    name: network.base.resource_manager
   vars:
-    operation: 'configure'
+    operation: configure
+  ansible.builtin.include_role:
+    name: network.base.resource_manager

--- a/roles/run/tasks/includes/gather.yaml
+++ b/roles/run/tasks/includes/gather.yaml
@@ -3,8 +3,8 @@
   ansible.builtin.include_tasks: includes/resources.yaml
 
 - name: Invoke gather function
-  include_role:
-    name: network.base.resource_manager
   vars:
-    operation: 'gather'
-    resources: "{{ bgp_resources }}"
+    operation: gather
+    resources: '{{ bgp_resources }}'
+  ansible.builtin.include_role:
+    name: network.base.resource_manager

--- a/roles/run/tasks/includes/health_check.yaml
+++ b/roles/run/tasks/includes/health_check.yaml
@@ -7,6 +7,6 @@
      health_checks: "{{ bgp_health | network.bgp.health_check_view(operation) }}"
 
 - name: BGP health checks
-  debug:
-     var: health_checks
   failed_when: "'unsuccessful' == health_checks.status"
+  ansible.builtin.debug:
+    var: health_checks

--- a/roles/run/tasks/includes/health_checks/eos.yaml
+++ b/roles/run/tasks/includes/health_checks/eos.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show ip bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/includes/health_checks/iosxr.yaml
+++ b/roles/run/tasks/includes/health_checks/iosxr.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/includes/health_checks/junos.yaml
+++ b/roles/run/tasks/includes/health_checks/junos.yaml
@@ -8,5 +8,5 @@
 
 
 - name: Show Summary facts
-  debug:
+  ansible.builtin.debug:
     msg: "{{ bgp_health }}"

--- a/roles/run/tasks/includes/health_checks/vyos.yaml
+++ b/roles/run/tasks/includes/health_checks/vyos.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show ip bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/main.yml
+++ b/roles/run/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include tasks
-  include_tasks: includes/{{ operation.name }}.yaml
   loop: "{{ operations }}"
   loop_control:
     loop_var: operation
+  ansible.builtin.include_tasks: includes/{{ operation.name }}.yaml


### PR DESCRIPTION
 It appears that there have been some changes made to the YAML files in a Git repository. Here's a summary of the changes:

1. In `roles/run/tasks/includes/gather.yaml`, the variables for the `include_role` task have been updated to use the new Ansible syntax (`ansible.builtin.include_role` instead of just `include_role`). The variable `operation` and `resources` have also been updated accordingly.
2. In `roles/run/tasks/includes/health_check.yaml`, the `debug` task has been replaced with `ansible.builtin.debug`.
3. In several files under `roles/run/tasks/includes/health_checks`, the `cli_parse` module has been replaced with `ansible.utils.cli_parse`.
4. In `roles/run/tasks/main.yml`, the use of `include_tasks` has been updated to use the new Ansible syntax (`ansible.builtin.include_tasks` instead of just `include_tasks`).

Overall, these changes seem to be related to updating the Ansible tasks and modules to use the new Ansible 2.10 syntax. The Git diff shows the differences between the old and new versions of each file.