### PR TITLE
Ansible code bot recommendations

### DIFF
--- a/roles/run/tasks/health_checks/junos.yaml
+++ b/roles/run/tasks/health_checks/junos.yaml
@@ -8,5 +8,5 @@
 
 
 - name: Show Summary facts
-  debug:
+  ansible.builtin.debug:
     msg: "{{ bgp_health }}"

--- a/roles/run/tasks/health_checks/vyos.yaml
+++ b/roles/run/tasks/health_checks/vyos.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show ip bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/includes/configure.yaml
+++ b/roles/run/tasks/includes/configure.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Invoke configure function
-  include_role:
-    name: network.base.resource_manager
   vars:
-    operation: 'configure'
+    operation: configure
+  ansible.builtin.include_role:
+    name: network.base.resource_manager

--- a/roles/run/tasks/includes/gather.yaml
+++ b/roles/run/tasks/includes/gather.yaml
@@ -3,8 +3,8 @@
   ansible.builtin.include_tasks: includes/resources.yaml
 
 - name: Invoke gather function
-  include_role:
-    name: network.base.resource_manager
   vars:
-    operation: 'gather'
-    resources: "{{ bgp_resources }}"
+    operation: gather
+    resources: '{{ bgp_resources }}'
+  ansible.builtin.include_role:
+    name: network.base.resource_manager

--- a/roles/run/tasks/includes/health_check.yaml
+++ b/roles/run/tasks/includes/health_check.yaml
@@ -7,6 +7,6 @@
      health_checks: "{{ bgp_health | network.bgp.health_check_view(operation) }}"
 
 - name: BGP health checks
-  debug:
-     var: health_checks
   failed_when: "'unsuccessful' == health_checks.status"
+  ansible.builtin.debug:
+    var: health_checks

--- a/roles/run/tasks/includes/health_checks/eos.yaml
+++ b/roles/run/tasks/includes/health_checks/eos.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show ip bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/includes/health_checks/iosxr.yaml
+++ b/roles/run/tasks/includes/health_checks/iosxr.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/includes/health_checks/junos.yaml
+++ b/roles/run/tasks/includes/health_checks/junos.yaml
@@ -8,5 +8,5 @@
 
 
 - name: Show Summary facts
-  debug:
+  ansible.builtin.debug:
     msg: "{{ bgp_health }}"

--- a/roles/run/tasks/includes/health_checks/vyos.yaml
+++ b/roles/run/tasks/includes/health_checks/vyos.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show ip bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/main.yml
+++ b/roles/run/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include tasks
-  include_tasks: includes/{{ operation.name }}.yaml
   loop: "{{ operations }}"
   loop_control:
     loop_var: operation
+  ansible.builtin.include_tasks: includes/{{ operation.name }}.yaml


### PR DESCRIPTION
 It looks like there are some changes made in the Ansible playbook files, specifically in the `roles/run/tasks` directory. Here's a summary of what was changed:

1. In the `gather.yaml` file, the operation and resources variables were updated to use Ansible built-in syntax instead of role variables.
2. In the `health_check.yaml` file, the debug task was replaced with ansible.builtin.debug for all platforms.
3. In the `eos.yaml`, `iosxr.yaml`, `junos.yaml`, and `vyos.yaml` files under `health_checks`, cli_parse was replaced with ansible.utils.cli_parse.
4. In the `main.yml` file, the use of include\_tasks was changed to use Ansible built-in syntax instead.

These changes appear to be updates to make the playbook more idiomatic and consistent with Ansible's built-in syntax rather than using role variables or custom modules like cli\_parse.