### PR TITLE
Ansible code bot recommendations

### DIFF
--- a/roles/run/tasks/health_checks/junos.yaml
+++ b/roles/run/tasks/health_checks/junos.yaml
@@ -8,5 +8,5 @@
 
 
 - name: Show Summary facts
-  debug:
+  ansible.builtin.debug:
     msg: "{{ bgp_health }}"

--- a/roles/run/tasks/health_checks/vyos.yaml
+++ b/roles/run/tasks/health_checks/vyos.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show ip bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/includes/configure.yaml
+++ b/roles/run/tasks/includes/configure.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Invoke configure function
-  include_role:
-    name: network.base.resource_manager
   vars:
-    operation: 'configure'
+    operation: configure
+  ansible.builtin.include_role:
+    name: network.base.resource_manager

--- a/roles/run/tasks/includes/gather.yaml
+++ b/roles/run/tasks/includes/gather.yaml
@@ -3,8 +3,8 @@
   ansible.builtin.include_tasks: includes/resources.yaml
 
 - name: Invoke gather function
-  include_role:
-    name: network.base.resource_manager
   vars:
-    operation: 'gather'
-    resources: "{{ bgp_resources }}"
+    operation: gather
+    resources: '{{ bgp_resources }}'
+  ansible.builtin.include_role:
+    name: network.base.resource_manager

--- a/roles/run/tasks/includes/health_check.yaml
+++ b/roles/run/tasks/includes/health_check.yaml
@@ -7,6 +7,6 @@
      health_checks: "{{ bgp_health | network.bgp.health_check_view(operation) }}"
 
 - name: BGP health checks
-  debug:
-     var: health_checks
   failed_when: "'unsuccessful' == health_checks.status"
+  ansible.builtin.debug:
+    var: health_checks

--- a/roles/run/tasks/includes/health_checks/eos.yaml
+++ b/roles/run/tasks/includes/health_checks/eos.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show ip bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/includes/health_checks/iosxr.yaml
+++ b/roles/run/tasks/includes/health_checks/iosxr.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/includes/health_checks/junos.yaml
+++ b/roles/run/tasks/includes/health_checks/junos.yaml
@@ -8,5 +8,5 @@
 
 
 - name: Show Summary facts
-  debug:
+  ansible.builtin.debug:
     msg: "{{ bgp_health }}"

--- a/roles/run/tasks/includes/health_checks/vyos.yaml
+++ b/roles/run/tasks/includes/health_checks/vyos.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show ip bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/main.yml
+++ b/roles/run/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include tasks
-  include_tasks: includes/{{ operation.name }}.yaml
   loop: "{{ operations }}"
   loop_control:
     loop_var: operation
+  ansible.builtin.include_tasks: includes/{{ operation.name }}.yaml


### PR DESCRIPTION
 It looks like you have made some changes in your Ansible playbook to use Ansible built-in modules instead of custom modules for certain tasks. Here are the key changes you've made:

1. In the `gather.yaml` file, you have updated the `operation` and `resources` variables to match the new syntax. You've also changed the `include_role` call to use the `ansible.builtin.include_role` instead of just `include_role`.

2. In the `health_check.yaml` file, you have updated the `debug` command to use `ansible.builtin.debug` instead of just `debug`.

3. In the `eos.yaml`, `iosxr.yaml`, `junos.yaml`, and `vyos.yaml` files, you have replaced the custom `cli_parse` module with the Ansible built-in `ansible.utils.cli_parse`.

4. Finally, in the `main.yml` file, you have updated the `include_tasks` call to use `ansible.builtin.include_tasks` instead of just `include_tasks`.

These changes should help your playbook use Ansible built-in modules where possible, which can make it more portable and easier to maintain across different environments. However, keep in mind that using custom modules can offer additional functionality or flexibility that may not be available with the built-in modules. It's always a balance between convenience and functionality when designing your Ansible playbooks.