### PR TITLE
Ansible code bot recommendations

### DIFF
--- a/playbooks/Network/get_network_adapter_details.yml
+++ b/playbooks/Network/get_network_adapter_details.yml
@@ -4,19 +4,16 @@
   gather_facts: False
   tasks:
     - name: Validate server authentication input provided by user
-      fail:
-        msg: "username/password or cert_file/key_file or auth_token is mandatory"
       when:
-        - (username is not defined or password is not defined) and (cert_file is not defined or key_file is not defined) and (auth_token is not defined)
+      - (username is not defined or password is not defined) and (cert_file is not defined or key_file is not defined) and (auth_token is not defined)
+      ansible.builtin.fail:
+        msg: "username/password or cert_file/key_file or auth_token is mandatory"
 
     - name: Fail when more than one valid authentication method is provided
-      fail:
-        msg: "Only one authentication method is allowed. Provide either username/password or cert_file/key_file or auth_token."
       when:
-        - ((username is defined or password is defined) and (cert_file is defined or key_file is defined) and auth_token is defined) or
-          ((username is defined or password is defined) and (cert_file is defined or key_file is defined)) or
-          ((username is defined or password is defined) and auth_token is defined) or
-          ((cert_file is defined or key_file is defined) and auth_token is defined)
+      - ((username is defined or password is defined) and (cert_file is defined or key_file is defined) and auth_token is defined) or ((username is defined or password is defined) and (cert_file is defined or key_file is defined)) or ((username is defined or password is defined) and auth_token is defined) or ((cert_file is defined or key_file is defined) and auth_token is defined)
+      ansible.builtin.fail:
+        msg: "Only one authentication method is allowed. Provide either username/password or cert_file/key_file or auth_token."
 
     - name: Get physical network adapter details when username and password are defined
       block:

--- a/playbooks/create_output_file.yml
+++ b/playbooks/create_output_file.yml
@@ -1,12 +1,14 @@
 ---
   - name: Define timestamp
-    set_fact: timestamp="{{ lookup('pipe', 'date +%Y%m%d_%H%M%S') }}"
     run_once: true
+    ansible.builtin.set_fact:
+      timestamp: '"{{'
 
   - name: Define file to place results
-    set_fact: template={{rootdir}}/{{host}}/{{host}}_{{datatype}}_{{timestamp}}
+    ansible.builtin.set_fact:
+      template: '{{rootdir}}/{{host}}/{{host}}_{{datatype}}_{{timestamp}}'
 
   - name: Create dropoff directory for host
-    file:
+    ansible.builtin.file:
       path: "{{ rootdir }}/{{ host }}"
       state: directory

--- a/playbooks/disable_pxe.yml
+++ b/playbooks/disable_pxe.yml
@@ -10,37 +10,37 @@
 
   tasks:
   - name: Create session
-    redfish_command:
+    register: result
+    community.general.redfish_command:
       category: Sessions
       command: CreateSession
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-    register: result
 
   - name: Set {{ bios_attr }}
-    redfish_config:
+    register: bios_attribute
+    community.general.redfish_config:
       category: Systems
       command: SetBiosAttributes
       bios_attributes: "{{ bios_attr }}"
       baseuri: "{{ baseuri }}"
-      # username: "{{ username }}"
-      # password: "{{ password }}"
+        # username: "{{ username }}"
+        # password: "{{ password }}"
       auth_token: "{{ result.session.token }}"
-    register: bios_attribute
 
   - name: Reboot system to apply new BIOS settings
-    redfish_command:
+    when: bios_attribute.changed
+    community.general.redfish_command:
       category: Systems
       command: PowerReboot
       baseuri: "{{ baseuri }}"
-      # username: "{{ username }}"
-      # password: "{{ password }}"
+        # username: "{{ username }}"
+        # password: "{{ password }}"
       auth_token: "{{ result.session.token }}"
-    when: bios_attribute.changed
 
   - name: Delete session using security token created by CreateSesssion above
-    redfish_command:
+    community.general.redfish_command:
       category: Sessions
       command: DeleteSession
       baseuri: "{{ baseuri }}"

--- a/playbooks/submit_service_quota_increase.yml
+++ b/playbooks/submit_service_quota_increase.yml
@@ -1,15 +1,12 @@
 ---
 - name: Get service quota change history in region {{ customer_account_region }}
   ansible.builtin.command:
-    cmd: "aws --region {{ customer_account_region }} service-quotas list-requested-service-quota-change-history-by-quota
-             --service-code {{ item.service_code }} --quota-code {{ item.quota_code }}"
+    cmd: "aws --region {{ customer_account_region }} service-quotas list-requested-service-quota-change-history-by-quota --service-code {{ item.service_code }} --quota-code {{ item.quota_code }}"
   register: quota_change_history
   changed_when: false
 
 - name: Submit a new quota request in region {{ customer_account_region }} # noqa name[template]
-  when: ((quota_change_history.stdout | from_json).RequestedQuotas | length == 0) or
-        (((quota_change_history.stdout | from_json).RequestedQuotas[0].DesiredValue | int) != (item.value | int))
+  when: ((quota_change_history.stdout | from_json).RequestedQuotas | length == 0) or (((quota_change_history.stdout | from_json).RequestedQuotas[0].DesiredValue | int) != (item.value | int))
   ansible.builtin.command:
-    cmd: "aws --region {{ customer_account_region }} service-quotas request-service-quota-increase
-             --service-code {{ item.service_code }} --quota-code {{ item.quota_code }} --desired-value {{ item.value }}"
+    cmd: "aws --region {{ customer_account_region }} service-quotas request-service-quota-increase --service-code {{ item.service_code }} --quota-code {{ item.quota_code }} --desired-value {{ item.value }}"
   changed_when: false

--- a/playbooks/sync_github_teams_users.yml
+++ b/playbooks/sync_github_teams_users.yml
@@ -6,17 +6,17 @@
 - name: Validate the AWS IAM group name and managed policy
   ansible.builtin.assert:
     that:
-      - iam_managed_policy != ""
+    - iam_managed_policy != ""
     fail_msg: The required IAM value was not found.
     success_msg: Required IAM value is available.
 
 - name: Validate the GitHub organization and access token
   ansible.builtin.assert:
     that:
-      - github_group_name != ""
-      - github_access_token != ""
-      - github_organization != ""
-      - github_teams is defined
+    - github_group_name != ""
+    - github_access_token != ""
+    - github_organization != ""
+    - github_teams is defined
     fail_msg: The required GitHub value was not found.
     success_msg: Required GitHub values are available.
 
@@ -27,12 +27,12 @@
     name: "{{ github_group_name }}"
   register: github_team_users
   when:
-    - github_group_name in github_teams.teams
+  - github_group_name in github_teams.teams
 
 - name: Ensure AWS user exists
   amazon.aws.iam_user:
     managed_policies:
-      - IAMUserChangePassword
+    - IAMUserChangePassword
     name: "{{ user_item }}"
     # For now we will generate a random password here so that Console UI access will be allowed
     # but we do not have a way yet to get info to end user.  So an admin will still have
@@ -49,21 +49,20 @@
   loop_control:
     loop_var: user_item
   when:
-    - github_group_name in github_teams.teams
+  - github_group_name in github_teams.teams
 
 - name: Ensure group and users have correct policy
-  amazon.aws.iam_group:
+  when:
+  - github_group_name in github_teams.teams
+  community.aws.iam_group:
     name: "{{ github_group_name }}"
     managed_policies:
-      - "{{ iam_managed_policy }}"
-    # Ensure we don't pick up a stray AWS_PROFILE
+    - '{{ iam_managed_policy }}'
     profile: ""
     purge_policies: true
     purge_users: true
     users: "{{ github_team_users.members }}"
     state: present
-  when:
-    - github_group_name in github_teams.teams
 
 - name: Create 'Ansible-SaaS-QE-Policies' Policy
   amazon.aws.iam_policy:

--- a/playbooks/update_repo_custom_properties.yml
+++ b/playbooks/update_repo_custom_properties.yml
@@ -17,7 +17,7 @@
     headers:
       Accept: application/vnd.github+json
       Authorization: token {{ github_token }}
-      X-GitHub-Api-Version: "2022-11-28"
+      X-GitHub-Api-Version: '2022-11-28'
     status_code: 200
   register: existing_properties
 
@@ -29,7 +29,7 @@
   ansible.builtin.set_fact:
     dict_properties: "{{ dict_properties | ansible.builtin.combine({item.property_name: item.value}) }}"
   with_items:
-    - "{{ existing_properties.json }}"
+  - '{{ existing_properties.json }}'
 
 - name: Concat dictionaries and generate new properties
   ansible.builtin.set_fact:
@@ -42,7 +42,7 @@
     headers:
       Accept: application/vnd.github+json
       Authorization: token {{ github_token }}
-      X-GitHub-Api-Version: "2022-11-28"
+      X-GitHub-Api-Version: '2022-11-28'
     body_format: json
     body: "{\"properties\":{{ result_properties | dict2items(key_name='property_name', value_name='value') }}}"
     status_code: 204

--- a/roles/run/tasks/health_checks/junos.yaml
+++ b/roles/run/tasks/health_checks/junos.yaml
@@ -8,5 +8,5 @@
 
 
 - name: Show Summary facts
-  debug:
+  ansible.builtin.debug:
     msg: "{{ bgp_health }}"

--- a/roles/run/tasks/health_checks/vyos.yaml
+++ b/roles/run/tasks/health_checks/vyos.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show ip bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/includes/configure.yaml
+++ b/roles/run/tasks/includes/configure.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Invoke configure function
-  include_role:
-    name: network.base.resource_manager
   vars:
-    operation: 'configure'
+    operation: configure
+  ansible.builtin.include_role:
+    name: network.base.resource_manager

--- a/roles/run/tasks/includes/gather.yaml
+++ b/roles/run/tasks/includes/gather.yaml
@@ -3,8 +3,8 @@
   ansible.builtin.include_tasks: includes/resources.yaml
 
 - name: Invoke gather function
-  include_role:
-    name: network.base.resource_manager
   vars:
-    operation: 'gather'
-    resources: "{{ bgp_resources }}"
+    operation: gather
+    resources: '{{ bgp_resources }}'
+  ansible.builtin.include_role:
+    name: network.base.resource_manager

--- a/roles/run/tasks/includes/health_check.yaml
+++ b/roles/run/tasks/includes/health_check.yaml
@@ -4,9 +4,9 @@
 
 - name: Set health checks fact
   ansible.builtin.set_fact:
-     health_checks: "{{ bgp_health | network.bgp.health_check_view(operation) }}"
+    health_checks: "{{ bgp_health | network.bgp.health_check_view(operation) }}"
 
 - name: BGP health checks
-  debug:
-     var: health_checks
   failed_when: "'unsuccessful' == health_checks.status"
+  ansible.builtin.debug:
+    var: health_checks

--- a/roles/run/tasks/includes/health_checks/eos.yaml
+++ b/roles/run/tasks/includes/health_checks/eos.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show ip bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/includes/health_checks/iosxr.yaml
+++ b/roles/run/tasks/includes/health_checks/iosxr.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/includes/health_checks/junos.yaml
+++ b/roles/run/tasks/includes/health_checks/junos.yaml
@@ -8,5 +8,5 @@
 
 
 - name: Show Summary facts
-  debug:
+  ansible.builtin.debug:
     msg: "{{ bgp_health }}"

--- a/roles/run/tasks/includes/health_checks/vyos.yaml
+++ b/roles/run/tasks/includes/health_checks/vyos.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Parse bgp summary
-  cli_parse:
+  ansible.utils.cli_parse:
     command: "show ip bgp summary"
     parser:
       name: ansible.netcommon.content_templates

--- a/roles/run/tasks/test_play.yml
+++ b/roles/run/tasks/test_play.yml
@@ -1,20 +1,18 @@
 ---
 - name: Include tasks
-  include_tasks: includes/{{ operation.name }}.yaml
   loop: "{{ operations }}"
   loop_control:
     loop_var: operation
+  ansible.builtin.include_tasks: includes/{{ operation.name }}.yaml
 
 - name: Validate input provided by user
-  fail:
-    msg: username/password or cert_file/key_file or auth_token is mandatory
   when:
-    - (username is not defined or password is not defined) and (cert_file is not defined or key_file is not defined) and (auth_token is not defined)
+  - (username is not defined or password is not defined) and (cert_file is not defined or key_file is not defined) and (auth_token is not defined)
+  ansible.builtin.fail:
+    msg: username/password or cert_file/key_file or auth_token is mandatory
 
 - name: Fail when more than one valid authentication method is provided
-  fail:
-    msg: Only one authentication method is allowed. Provide either username/password or cert_file/key_file or auth_token.
   when:
-    - ((username is defined or password is defined) and (cert_file is defined or key_file is defined) and auth_token is defined) or ((username is defined or password
-      is defined) and (cert_file is defined or key_file is defined)) or ((username is defined or password is defined) and auth_token is defined) or ((cert_file
-      is defined or key_file is defined) and auth_token is defined)
+  - ((username is defined or password is defined) and (cert_file is defined or key_file is defined) and auth_token is defined) or ((username is defined or password is defined) and (cert_file is defined or key_file is defined)) or ((username is defined or password is defined) and auth_token is defined) or ((cert_file is defined or key_file is defined) and auth_token is defined)
+  ansible.builtin.fail:
+    msg: Only one authentication method is allowed. Provide either username/password or cert_file/key_file or auth_token.


### PR DESCRIPTION
Based on the provided documents, I've summarized the relevant information as follows:

**Summary (Based on 4 documents and 3 config rules):**

* Ansible code bot has identified several rule violations in the repo playbooks. Here's a breakdown of the violations based on the relevant rules:
	+ The playbook uses implicit Jinja2 templating for `changed_when`, `failed_when`, `until`, and `when` fields, which is not required. This is against config rule [insert description here].
	+ The playbook suggests removing braces for `changed_when`, `failed_when`, `until`, and `when` fields, as per the relevant config rules.
	+ The playbook uses YAML syntax that may be considered a warning instead of an error, which can be fixed by adding tag identifiers to the warn_list in the configuration.

**Number of files:** 4 documents related to Ansible code bot config rules.